### PR TITLE
feat(backend): Anthropic provider env mapping and default model

### DIFF
--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -30,6 +30,11 @@ process.env.AGENT = "1"
 process.env.OPENCODE = "1"
 process.env.OPENCODE_PID = String(process.pid)
 
+// Map ANTHROPIC_AUTH_TOKEN → ANTHROPIC_API_KEY for @ai-sdk/anthropic compatibility
+if (process.env.ANTHROPIC_AUTH_TOKEN && !process.env.ANTHROPIC_API_KEY) {
+  process.env.ANTHROPIC_API_KEY = process.env.ANTHROPIC_AUTH_TOKEN
+}
+
 const port = Number(process.env.PORT ?? 4096)
 const hostname = process.env.HOST ?? "0.0.0.0"
 

--- a/opencode.json
+++ b/opencode.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://opencode.ai/config.json",
+  "model": "anthropic/claude-sonnet-4-5"
+}


### PR DESCRIPTION
## Summary
- 启动时映射 `ANTHROPIC_AUTH_TOKEN` → `ANTHROPIC_API_KEY`，兼容 @ai-sdk/anthropic
- 添加项目级 `opencode.json`，默认模型设为 `anthropic/claude-sonnet-4-5`

Refs #3

## Changes
- `backend/src/index.ts`: 环境变量映射逻辑
- `opencode.json`: 项目级 LLM 配置

## Test Plan
- [x] Backend 类型检查通过
- [ ] 配置正确的 Anthropic API key 后，发送消息可收到 LLM 响应