### PR TITLE
fix(web): add missing CSS for task and form pages

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -983,6 +983,513 @@ a {
   border-color: rgba(239, 68, 68, 0.28);
 }
 
+/* ── Page Shell (NewTaskPage, TaskDetailPage) ── */
+
+.page-shell {
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  min-height: calc(100vh - 79px);
+  padding: 48px 24px;
+}
+
+.page-card {
+  width: 100%;
+  max-width: 720px;
+  padding: 36px;
+  border-radius: 20px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  backdrop-filter: blur(12px);
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.14);
+}
+
+.page-card.narrow {
+  max-width: 560px;
+}
+
+.page-heading {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+  margin-bottom: 16px;
+}
+
+.page-heading h2 {
+  font-size: 1.4rem;
+  line-height: 1.2;
+}
+
+.eyebrow {
+  color: #8fb7ff;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-size: 0.72rem;
+  margin-bottom: 6px;
+}
+
+.status-pill {
+  padding: 6px 12px;
+  border-radius: 999px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  background: rgba(59, 130, 246, 0.14);
+  color: #8fb7ff;
+  white-space: nowrap;
+}
+
+.page-copy {
+  color: var(--text-muted);
+  line-height: 1.6;
+  margin-bottom: 24px;
+}
+
+/* ── Task Form (NewTaskPage) ── */
+
+.task-form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.field-label {
+  font-size: 0.85rem;
+  font-weight: 500;
+  color: var(--text-muted);
+}
+
+.text-field {
+  width: 100%;
+  padding: 12px 14px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text);
+  font-size: 0.92rem;
+}
+
+.text-field:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.12);
+}
+
+.textarea-field {
+  width: 100%;
+  padding: 12px 14px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text);
+  font-size: 0.92rem;
+  resize: vertical;
+  min-height: 120px;
+  line-height: 1.5;
+}
+
+.textarea-field:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.12);
+}
+
+.form-error {
+  color: var(--danger);
+  font-size: 0.85rem;
+}
+
+.task-actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 8px;
+}
+
+.primary-action {
+  padding: 11px 24px;
+  background: var(--accent);
+  color: white;
+  border-radius: var(--radius);
+  font-weight: 500;
+  font-size: 0.92rem;
+  transition: background 0.15s;
+}
+
+.primary-action:hover:not(:disabled) {
+  background: var(--accent-hover);
+}
+
+.primary-action:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.secondary-action {
+  padding: 11px 24px;
+  background: var(--bg-secondary);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  font-size: 0.92rem;
+  transition: background 0.15s;
+}
+
+.secondary-action:hover {
+  background: var(--bg-hover);
+}
+
+.link-action {
+  display: inline-flex;
+  align-items: center;
+  text-decoration: none;
+}
+
+/* ── Task Layout (TaskDetailPage) ── */
+
+.task-layout {
+  display: flex;
+  min-height: calc(100vh - 79px);
+}
+
+.task-summary {
+  width: 300px;
+  min-width: 300px;
+  padding: 32px 24px;
+  border-right: 1px solid var(--border);
+  background: var(--bg-secondary);
+}
+
+.task-summary h2 {
+  font-size: 1.2rem;
+  margin-bottom: 20px;
+}
+
+.meta-list {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  margin-bottom: 24px;
+}
+
+.meta-list dt {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  margin-bottom: 2px;
+}
+
+.meta-list dd {
+  font-size: 0.85rem;
+  word-break: break-all;
+}
+
+.task-chat {
+  flex: 1;
+  overflow-y: auto;
+}
+
+/* ── Task Process (TaskProcessPage) ── */
+
+.task-process-page {
+  padding: 28px 32px;
+  max-width: 960px;
+}
+
+.task-process-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+  margin-bottom: 28px;
+}
+
+.task-process-header h2 {
+  font-size: 1.3rem;
+  margin-bottom: 4px;
+}
+
+.task-process-kicker {
+  color: #8fb7ff;
+  text-transform: uppercase;
+  letter-spacing: 0.14em;
+  font-size: 0.72rem;
+  margin-bottom: 6px;
+}
+
+.task-process-meta {
+  display: flex;
+  gap: 16px;
+  font-size: 0.78rem;
+  color: var(--text-muted);
+  margin-top: 4px;
+}
+
+.task-process-actions {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.task-process-badge {
+  padding: 6px 14px;
+  border-radius: 999px;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.task-process-badge.idle {
+  background: rgba(148, 163, 184, 0.14);
+  color: var(--text-muted);
+}
+
+.task-process-badge.live {
+  background: rgba(34, 197, 94, 0.14);
+  color: #8ef0a7;
+  animation: pulse-glow 2s ease-in-out infinite;
+}
+
+@keyframes pulse-glow {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.7; }
+}
+
+/* ── Progress Panel ── */
+
+.task-progress-panel {
+  padding: 20px;
+  border-radius: 16px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  margin-bottom: 20px;
+}
+
+.task-progress-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 12px;
+}
+
+.task-progress-header h3 {
+  font-size: 0.95rem;
+  margin-bottom: 4px;
+}
+
+.task-progress-header p {
+  font-size: 0.78rem;
+  color: var(--text-muted);
+}
+
+.task-progress-header strong {
+  font-size: 1.4rem;
+  color: var(--accent);
+}
+
+.task-progress-bar {
+  height: 6px;
+  border-radius: 3px;
+  background: rgba(148, 163, 184, 0.16);
+  overflow: hidden;
+}
+
+.task-progress-fill {
+  height: 100%;
+  border-radius: 3px;
+  background: linear-gradient(90deg, var(--accent), #14b8a6);
+  transition: width 0.4s ease;
+}
+
+/* ── Live Output Panel ── */
+
+.task-live-panel {
+  padding: 16px 20px;
+  border-radius: 16px;
+  background: rgba(2, 6, 23, 0.56);
+  border: 1px solid var(--border);
+  margin-bottom: 20px;
+}
+
+.task-section-title {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+}
+
+.task-section-title h3 {
+  font-size: 0.92rem;
+}
+
+.task-section-title span {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  font-family: ui-monospace, monospace;
+}
+
+.task-live-panel pre {
+  max-height: 240px;
+  overflow: auto;
+  font-size: 0.78rem;
+  line-height: 1.5;
+  color: var(--text-muted);
+  white-space: pre-wrap;
+  word-break: break-all;
+}
+
+/* ── Steps Panel ── */
+
+.task-steps-panel {
+  padding: 20px;
+  border-radius: 16px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+}
+
+.task-steps-list {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.task-step-card {
+  display: flex;
+  gap: 14px;
+  padding: 14px 16px;
+  border-radius: 12px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  transition: border-color 0.15s;
+}
+
+.task-step-card.status-completed {
+  border-left: 3px solid var(--success);
+}
+
+.task-step-card.status-running {
+  border-left: 3px solid var(--warning);
+}
+
+.task-step-card.status-error {
+  border-left: 3px solid var(--danger);
+}
+
+.task-step-card.status-pending {
+  border-left: 3px solid var(--border);
+}
+
+.task-step-index {
+  font-size: 0.75rem;
+  font-weight: 700;
+  color: var(--text-muted);
+  min-width: 24px;
+  padding-top: 2px;
+  font-family: ui-monospace, monospace;
+}
+
+.task-step-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.task-step-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 10px;
+  margin-bottom: 6px;
+}
+
+.task-step-header h4 {
+  font-size: 0.88rem;
+  line-height: 1.3;
+}
+
+.task-step-header p {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  margin-top: 2px;
+}
+
+.task-step-status {
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.task-step-status.status-completed {
+  background: rgba(34, 197, 94, 0.14);
+  color: var(--success);
+}
+
+.task-step-status.status-running {
+  background: rgba(245, 158, 11, 0.14);
+  color: var(--warning);
+}
+
+.task-step-status.status-error {
+  background: rgba(239, 68, 68, 0.14);
+  color: var(--danger);
+}
+
+.task-step-status.status-pending {
+  background: rgba(148, 163, 184, 0.14);
+  color: var(--text-muted);
+}
+
+.task-step-preview {
+  font-size: 0.8rem;
+  color: var(--text-muted);
+  line-height: 1.5;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.task-step-preview.is-empty {
+  font-style: italic;
+  opacity: 0.5;
+}
+
+.task-process-empty {
+  text-align: center;
+  padding: 40px 20px;
+  color: var(--text-muted);
+  font-size: 0.9rem;
+}
+
+.task-process-empty.task-process-error {
+  color: var(--danger);
+}
+
+/* ── Responsive: Task Layout ── */
+
+@media (max-width: 920px) {
+  .task-layout {
+    flex-direction: column;
+  }
+
+  .task-summary {
+    width: 100%;
+    min-width: 0;
+    border-right: none;
+    border-bottom: 1px solid var(--border);
+    padding: 20px;
+  }
+
+  .task-process-page {
+    padding: 20px 16px;
+  }
+
+  .task-process-header {
+    flex-direction: column;
+  }
+}
+
 ::-webkit-scrollbar {
   width: 6px;
 }


### PR DESCRIPTION
## Summary
- 补全 NewTaskPage、TaskDetailPage、TaskProcessPage 缺失的 ~30 个 CSS 类
- 包含页面布局、表单样式、进度条、步骤卡片、实时输出面板、响应式适配

Refs #2

## Changes
- `web/src/App.css`: 新增 507 行样式

## Test Plan
- [x] `npx tsc --noEmit` 通过
- [x] `npm run build` 通过 (CSS 从 13.9KB → 20.7KB)
- [ ] 浏览器验证 NewTask、TaskDetail、TaskProcess 页面样式正常