### PR TITLE
feat(web): replace alert() with toast notifications

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1490,6 +1490,84 @@ a {
   }
 }
 
+/* ── Toast ── */
+
+.toast-container {
+  position: fixed;
+  top: 80px;
+  right: 24px;
+  z-index: 100;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  max-width: 420px;
+}
+
+.toast {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 16px;
+  border-radius: 12px;
+  font-size: 0.85rem;
+  line-height: 1.4;
+  backdrop-filter: blur(12px);
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.24);
+  animation: toast-in 0.25s ease;
+}
+
+.toast-error {
+  background: rgba(239, 68, 68, 0.16);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+  color: #fca5a5;
+}
+
+:root[data-theme='light'] .toast-error {
+  background: rgba(239, 68, 68, 0.1);
+  color: #dc2626;
+}
+
+.toast-success {
+  background: rgba(34, 197, 94, 0.16);
+  border: 1px solid rgba(34, 197, 94, 0.3);
+  color: #86efac;
+}
+
+.toast-info {
+  background: rgba(59, 130, 246, 0.16);
+  border: 1px solid rgba(59, 130, 246, 0.3);
+  color: #93c5fd;
+}
+
+.toast span {
+  flex: 1;
+}
+
+.toast-close {
+  background: transparent;
+  color: inherit;
+  opacity: 0.6;
+  padding: 2px 4px;
+  border-radius: 4px;
+  font-size: 0.75rem;
+  flex-shrink: 0;
+}
+
+.toast-close:hover {
+  opacity: 1;
+}
+
+@keyframes toast-in {
+  from {
+    opacity: 0;
+    transform: translateX(20px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
 ::-webkit-scrollbar {
   width: 6px;
 }

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react'
 import { NavLink, Navigate, Outlet, Route, Routes } from 'react-router-dom'
 import { healthCheck } from './api'
+import { ToastContainer } from './components/Toast'
 import { NewTaskPage } from './pages/NewTaskPage'
 import { SessionsPage } from './pages/SessionsPage'
 import { SkillsPage } from './pages/SkillsPage'
@@ -64,6 +65,7 @@ function AppLayout({
       <div className="route-view">
         <Outlet />
       </div>
+      <ToastContainer />
     </div>
   )
 }

--- a/web/src/components/ChatView.tsx
+++ b/web/src/components/ChatView.tsx
@@ -8,6 +8,7 @@ import {
   subscribeEvents,
 } from '../api'
 import type { Session, MessageWithParts, Part } from '../api'
+import { toast } from './Toast'
 
 interface Props {
   session: Session
@@ -122,7 +123,7 @@ export function ChatView({ session }: Props) {
       }, 500)
     } catch (e) {
       console.error('Send failed', e)
-      alert(`发送失败: ${e instanceof Error ? e.message : e}`)
+      toast(`发送失败: ${e instanceof Error ? e.message : e}`)
       setSending(false)
       setStreaming(false)
     }

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -2,6 +2,7 @@ import { useEffect } from 'react'
 import { listSessions, createSession, deleteSession } from '../api'
 import type { Session } from '../api'
 import type { Dispatch, MouseEvent, SetStateAction } from 'react'
+import { toast } from './Toast'
 
 interface Props {
   sessions: Session[]
@@ -30,7 +31,7 @@ export function Sidebar({ sessions, setSessions, activeSession, setActiveSession
       setActiveSession(session)
     } catch (e) {
       console.error('Failed to create session', e)
-      alert('创建会话失败')
+      toast('创建会话失败')
     }
   }
 

--- a/web/src/components/Toast.tsx
+++ b/web/src/components/Toast.tsx
@@ -1,0 +1,51 @@
+import { useState, useEffect, useCallback } from 'react'
+
+export type ToastType = 'error' | 'success' | 'info'
+
+interface Toast {
+  id: number
+  message: string
+  type: ToastType
+}
+
+let nextId = 0
+let globalAdd: ((message: string, type?: ToastType) => void) | null = null
+
+export function toast(message: string, type: ToastType = 'error') {
+  globalAdd?.(message, type)
+}
+
+export function ToastContainer() {
+  const [toasts, setToasts] = useState<Toast[]>([])
+
+  const add = useCallback((message: string, type: ToastType = 'error') => {
+    const id = ++nextId
+    setToasts((prev) => [...prev, { id, message, type }])
+    setTimeout(() => {
+      setToasts((prev) => prev.filter((t) => t.id !== id))
+    }, 5000)
+  }, [])
+
+  useEffect(() => {
+    globalAdd = add
+    return () => { globalAdd = null }
+  }, [add])
+
+  if (toasts.length === 0) return null
+
+  return (
+    <div className="toast-container">
+      {toasts.map((t) => (
+        <div key={t.id} className={`toast toast-${t.type}`}>
+          <span>{t.message}</span>
+          <button
+            onClick={() => setToasts((prev) => prev.filter((x) => x.id !== t.id))}
+            className="toast-close"
+          >
+            ✕
+          </button>
+        </div>
+      ))}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- 新增 Toast 组件，支持 error/success/info 三种类型，5 秒自动消失
- 替换 ChatView 和 Sidebar 中所有 `alert()` 为 `toast()`
- 添加 toast 相关 CSS（动画、暗色/亮色主题适配）

Refs #2

## Changes
- `web/src/components/Toast.tsx`: Toast 组件 + 全局 `toast()` 函数
- `web/src/components/ChatView.tsx`: alert → toast
- `web/src/components/Sidebar.tsx`: alert → toast
- `web/src/App.tsx`: 挂载 ToastContainer
- `web/src/App.css`: toast 样式

## Test Plan
- [x] `npx tsc --noEmit` 通过
- [x] `npm run build` 通过
- [ ] 浏览器验证：发送失败时右上角弹出 toast 而非 alert