### PR TITLE
feat: skill toggle API and frontend persistence

### DIFF
--- a/backend/src/server/server.ts
+++ b/backend/src/server/server.ts
@@ -386,6 +386,41 @@ export namespace Server {
           return c.json(skills)
         },
       )
+      .put(
+        "/skill/:name/toggle",
+        describeRoute({
+          summary: "Toggle skill",
+          description: "Enable or disable a skill by name.",
+          operationId: "app.skill.toggle",
+          responses: {
+            200: {
+              description: "Updated enabled state",
+              content: {
+                "application/json": {
+                  schema: resolver(z.object({ name: z.string(), enabled: z.boolean() })),
+                },
+              },
+            },
+          },
+        }),
+        validator(
+          "json",
+          z.object({
+            enabled: z.boolean(),
+          }),
+        ),
+        async (c) => {
+          const name = c.req.param("name")
+          const { enabled } = c.req.valid("json")
+          const settings = await Settings.get()
+          const current = settings.enabled_skills ?? []
+          const next = enabled
+            ? [...new Set([...current, name])]
+            : current.filter((s: string) => s !== name)
+          await Settings.update({ enabled_skills: next })
+          return c.json({ name, enabled })
+        },
+      )
       .get(
         "/plugin",
         describeRoute({

--- a/web/src/pages/SkillsPage.tsx
+++ b/web/src/pages/SkillsPage.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useState } from 'react'
 import { API_BASE_URL, type Skill } from '../api'
+import { toast } from '../components/Toast'
 
 type SkillCardProps = {
   skill: Skill
@@ -105,12 +106,29 @@ export function SkillsPage() {
     })
   }, [search, skills])
 
-  function handleToggle(skillId: string) {
+  async function handleToggle(skillId: string) {
+    const skill = skills.find((s) => s.id === skillId)
+    if (!skill) return
+    const newEnabled = !skill.enabled
     setSkills((currentSkills) =>
-      currentSkills.map((skill) =>
-        skill.id === skillId ? { ...skill, enabled: !skill.enabled } : skill,
+      currentSkills.map((s) =>
+        s.id === skillId ? { ...s, enabled: newEnabled } : s,
       ),
     )
+    try {
+      await fetch(`${API_BASE_URL}/skill/${encodeURIComponent(skill.name)}/toggle`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ enabled: newEnabled }),
+      })
+    } catch {
+      setSkills((currentSkills) =>
+        currentSkills.map((s) =>
+          s.id === skillId ? { ...s, enabled: !newEnabled } : s,
+        ),
+      )
+      toast('切换 Skill 状态失败')
+    }
   }
 
   return (


### PR DESCRIPTION
## Summary
- Backend: 新增 `PUT /skill/:name/toggle` 端点，通过 Settings 模块持久化到 `.claude/settings.json`
- Frontend: SkillsPage toggle 调用后端 API，乐观更新 + 失败回滚 + toast 提示

Closes #2

## Changes
- `backend/src/server/server.ts`: 新增 toggle 路由
- `web/src/pages/SkillsPage.tsx`: 对接 toggle API

## Test Plan
- [x] Backend `bunx tsc --noEmit` 通过
- [x] Frontend `npx tsc --noEmit` 通过
- [ ] 浏览器验证：toggle skill 后刷新页面状态保持