### PR TITLE
feat(web): Agent mode and Model selector in chat

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -344,10 +344,33 @@ a {
   align-items: center;
   gap: 1rem;
   background: rgba(255, 255, 255, 0.02);
+  flex-wrap: wrap;
 }
 
 .chat-header h2 {
   font-size: 1rem;
+}
+
+.chat-selectors {
+  display: flex;
+  gap: 8px;
+  margin-left: auto;
+}
+
+.chat-select {
+  padding: 6px 10px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--text);
+  font-size: 0.78rem;
+  cursor: pointer;
+  max-width: 200px;
+}
+
+.chat-select:focus {
+  outline: none;
+  border-color: var(--accent);
 }
 
 .session-id {

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -142,3 +142,47 @@ declare global {
     __OPENCODE_DIR__?: string
   }
 }
+
+// --- Agent & Provider ---
+
+export interface AgentInfo {
+  name: string
+  description?: string
+  mode: string
+}
+
+export interface ProviderModel {
+  id: string
+  providerID: string
+  name: string
+}
+
+export interface ProviderInfo {
+  id: string
+  name: string
+  models: Record<string, ProviderModel>
+}
+
+export async function listAgents() {
+  return request<AgentInfo[]>('/agent')
+}
+
+export async function listProviders() {
+  return request<{ all: ProviderInfo[] }>('/provider')
+}
+
+export async function sendMessageAsyncWithOptions(
+  sessionID: string,
+  parts: Array<{ type: string; [key: string]: unknown }>,
+  options?: { agent?: string; model?: { providerID: string; modelID: string } },
+) {
+  const res = await fetch(`${API_BASE_URL}/session/${sessionID}/prompt_async`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ parts, ...options }),
+  })
+  if (!res.ok) {
+    const text = await res.text()
+    throw new Error(`API ${res.status}: ${text}`)
+  }
+}

--- a/web/src/components/ChatView.tsx
+++ b/web/src/components/ChatView.tsx
@@ -3,11 +3,13 @@ import ReactMarkdown from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import {
   getMessages,
-  sendMessageAsync,
+  sendMessageAsyncWithOptions,
   abortSession,
   subscribeEvents,
+  listAgents,
+  listProviders,
 } from '../api'
-import type { Session, MessageWithParts, Part } from '../api'
+import type { Session, MessageWithParts, Part, AgentInfo, ProviderInfo } from '../api'
 import { toast } from './Toast'
 
 interface Props {
@@ -20,6 +22,10 @@ export function ChatView({ session }: Props) {
   const [files, setFiles] = useState<File[]>([])
   const [sending, setSending] = useState(false)
   const [streaming, setStreaming] = useState(false)
+  const [agents, setAgents] = useState<AgentInfo[]>([])
+  const [providers, setProviders] = useState<ProviderInfo[]>([])
+  const [selectedAgent, setSelectedAgent] = useState('')
+  const [selectedModel, setSelectedModel] = useState('')
   const messagesEndRef = useRef<HTMLDivElement>(null)
   const fileInputRef = useRef<HTMLInputElement>(null)
 
@@ -29,6 +35,29 @@ export function ChatView({ session }: Props) {
       .then(setMessages)
       .catch(console.error)
   }, [session.id])
+
+  // Load agents and providers
+  useEffect(() => {
+    listAgents()
+      .then((list) => {
+        const visible = list.filter((a) => a.mode !== 'subagent')
+        setAgents(visible)
+        if (!selectedAgent && visible.length > 0) {
+          setSelectedAgent(visible.find((a) => a.name === 'build')?.name ?? visible[0].name)
+        }
+      })
+      .catch(console.error)
+    listProviders()
+      .then((data) => {
+        setProviders(data.all)
+        if (!selectedModel && data.all.length > 0) {
+          const first = data.all[0]
+          const firstModel = Object.keys(first.models)[0]
+          if (firstModel) setSelectedModel(`${first.id}/${firstModel}`)
+        }
+      })
+      .catch(console.error)
+  }, [])
 
   // Subscribe to SSE events for real-time updates
   useEffect(() => {
@@ -111,7 +140,13 @@ export function ChatView({ session }: Props) {
       const prompt = trimmed || '请分析上传的文件内容，生成详细的分析报告。'
       parts.push({ type: 'text', text: prompt })
 
-      await sendMessageAsync(session.id, parts)
+      await sendMessageAsyncWithOptions(session.id, parts, {
+        agent: selectedAgent || undefined,
+        model: selectedModel ? {
+          providerID: selectedModel.split('/')[0],
+          modelID: selectedModel.split('/').slice(1).join('/'),
+        } : undefined,
+      })
 
       setInput('')
       setFiles([])
@@ -157,6 +192,38 @@ export function ChatView({ session }: Props) {
       <div className="chat-header">
         <h2>{session.title || '未命名会话'}</h2>
         <span className="session-id">{session.id}</span>
+        <div className="chat-selectors">
+          {agents.length > 0 && (
+            <select
+              className="chat-select"
+              value={selectedAgent}
+              onChange={(e) => setSelectedAgent(e.target.value)}
+              title="Agent 模式"
+            >
+              {agents.map((a) => (
+                <option key={a.name} value={a.name}>
+                  {a.name}
+                </option>
+              ))}
+            </select>
+          )}
+          {providers.length > 0 && (
+            <select
+              className="chat-select"
+              value={selectedModel}
+              onChange={(e) => setSelectedModel(e.target.value)}
+              title="Model"
+            >
+              {providers.map((p) =>
+                Object.values(p.models).map((m) => (
+                  <option key={`${p.id}/${m.id}`} value={`${p.id}/${m.id}`}>
+                    {m.name || m.id}
+                  </option>
+                )),
+              )}
+            </select>
+          )}
+        </div>
       </div>
 
       <div className="messages">


### PR DESCRIPTION
## Summary
- Chat header 新增 Agent 模式选择器（build/plan/explore）和 Model 选择器
- 新增 `listAgents`、`listProviders`、`sendMessageAsyncWithOptions` API
- 发送消息时携带选中的 agent 和 model 参数

Refs #16, Refs #11

## Changes
- `web/src/api.ts`: 新增 Agent/Provider 类型和 API 调用
- `web/src/components/ChatView.tsx`: 加载 agents/providers，header 添加选择器
- `web/src/App.css`: 选择器样式

## Test Plan
- [x] `npx tsc --noEmit` 通过
- [x] `npm run build` 通过
- [ ] 浏览器验证：chat header 显示 agent 和 model 下拉框
- [ ] 切换 agent 后发送消息，后端使用对应 agent 处理