### PR TITLE
feat(web): session search and Markdown export

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -236,6 +236,26 @@ a {
   margin-bottom: 0.75rem;
 }
 
+.sidebar-search {
+  padding: 0.5rem;
+  border-bottom: 1px solid var(--border);
+}
+
+.search-input {
+  width: 100%;
+  padding: 8px 12px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--text);
+  font-size: 0.82rem;
+}
+
+.search-input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
 .btn-new {
   width: 100%;
   padding: 0.7rem;
@@ -292,6 +312,24 @@ a {
   margin-top: 4px;
   font-size: 0.75rem;
   color: var(--text-muted);
+}
+
+.session-actions {
+  display: flex;
+  gap: 2px;
+}
+
+.btn-export {
+  background: transparent;
+  color: var(--text-muted);
+  padding: 2px 6px;
+  border-radius: 6px;
+  font-size: 0.8rem;
+}
+
+.btn-export:hover {
+  background: var(--accent);
+  color: white;
 }
 
 .btn-delete {

--- a/web/src/components/Sidebar.tsx
+++ b/web/src/components/Sidebar.tsx
@@ -1,5 +1,5 @@
-import { useEffect } from 'react'
-import { listSessions, createSession, deleteSession } from '../api'
+import { useEffect, useState, useMemo } from 'react'
+import { listSessions, createSession, deleteSession, getMessages } from '../api'
 import type { Session } from '../api'
 import type { Dispatch, MouseEvent, SetStateAction } from 'react'
 import { toast } from './Toast'
@@ -12,6 +12,8 @@ interface Props {
 }
 
 export function Sidebar({ sessions, setSessions, activeSession, setActiveSession }: Props) {
+  const [search, setSearch] = useState('')
+
   useEffect(() => {
     listSessions()
       .then((list) => {
@@ -22,6 +24,15 @@ export function Sidebar({ sessions, setSessions, activeSession, setActiveSession
         console.error('Failed to load sessions', error)
       })
   }, [setActiveSession, setSessions])
+
+  const filtered = useMemo(() => {
+    const keyword = search.trim().toLowerCase()
+    if (!keyword) return sessions
+    return sessions.filter((s) =>
+      (s.title || '').toLowerCase().includes(keyword) ||
+      s.id.toLowerCase().includes(keyword),
+    )
+  }, [search, sessions])
 
   async function handleCreate() {
     try {
@@ -50,22 +61,80 @@ export function Sidebar({ sessions, setSessions, activeSession, setActiveSession
       }
     } catch (err) {
       console.error('Failed to delete session', err)
+      toast('删除会话失败')
+    }
+  }
+
+  async function handleExport(e: MouseEvent, session: Session) {
+    e.stopPropagation()
+    try {
+      const messages = await getMessages(session.id)
+      const lines: string[] = [
+        `# ${session.title || '未命名会话'}`,
+        '',
+        `> Session ID: ${session.id}`,
+        `> Created: ${new Date(session.time.created).toLocaleString('zh-CN')}`,
+        '',
+        '---',
+        '',
+      ]
+      for (const msg of messages) {
+        const role = msg.info.role === 'user' ? 'User' : 'Assistant'
+        lines.push(`## ${role}`)
+        lines.push('')
+        for (const part of msg.parts) {
+          if (part.type === 'text' && part.text) {
+            lines.push(part.text)
+          } else if (part.type === 'tool') {
+            lines.push(`> Tool: ${part.tool} [${part.state?.status}]`)
+            if (part.state?.output) {
+              lines.push('```')
+              lines.push(part.state.output.slice(0, 2000))
+              lines.push('```')
+            }
+          }
+          lines.push('')
+        }
+        lines.push('---')
+        lines.push('')
+      }
+      const blob = new Blob([lines.join('\n')], { type: 'text/markdown' })
+      const url = URL.createObjectURL(blob)
+      const a = document.createElement('a')
+      a.href = url
+      a.download = `${(session.title || 'session').replace(/[^a-zA-Z0-9\u4e00-\u9fff-]/g, '_')}.md`
+      a.click()
+      URL.revokeObjectURL(url)
+      toast('导出成功', 'success')
+    } catch {
+      toast('导出失败')
     }
   }
 
   return (
     <aside className="sidebar">
       <div className="sidebar-header">
-        <h1>🤖 Agent Core</h1>
+        <h1>Agent Core</h1>
         <button className="btn-new" onClick={handleCreate}>
           + 新建会话
         </button>
       </div>
+      <div className="sidebar-search">
+        <input
+          type="search"
+          placeholder="搜索会话..."
+          value={search}
+          onChange={(e) => setSearch(e.target.value)}
+          className="search-input"
+        />
+      </div>
       <div className="session-list">
-        {sessions.length === 0 && (
-          <p className="no-sessions">暂无会话，点击上方按钮创建</p>
+        {filtered.length === 0 && (
+          <p className="no-sessions">
+            {search ? '没有匹配的会话' : '暂无会话，点击上方按钮创建'}
+          </p>
         )}
-        {sessions.map((s) => (
+        {filtered.map((s) => (
           <div
             key={s.id}
             className={`session-item ${activeSession?.id === s.id ? 'active' : ''}`}
@@ -74,13 +143,22 @@ export function Sidebar({ sessions, setSessions, activeSession, setActiveSession
             <div className="session-title">{s.title || '未命名会话'}</div>
             <div className="session-meta">
               <span>{new Date(s.time.created).toLocaleString('zh-CN')}</span>
-              <button
-                className="btn-delete"
-                onClick={(e) => handleDelete(e, s.id)}
-                title="删除"
-              >
-                ✕
-              </button>
+              <div className="session-actions">
+                <button
+                  className="btn-export"
+                  onClick={(e) => handleExport(e, s)}
+                  title="导出 Markdown"
+                >
+                  ↓
+                </button>
+                <button
+                  className="btn-delete"
+                  onClick={(e) => handleDelete(e, s.id)}
+                  title="删除"
+                >
+                  ✕
+                </button>
+              </div>
             </div>
           </div>
         ))}


### PR DESCRIPTION
## Summary
- Sidebar 新增搜索框，按标题/ID 过滤会话
- Sidebar 新增导出按钮，将会话导出为 Markdown 文件（含消息、工具调用）
- 删除失败时 toast 提示

Refs #15

## Changes
- `web/src/components/Sidebar.tsx`: 搜索、导出、错误提示
- `web/src/App.css`: 搜索框和导出按钮样式

## Test Plan
- [x] `npx tsc --noEmit` 通过
- [x] `npm run build` 通过
- [ ] 浏览器验证：搜索过滤、导出下载