### PR TITLE
feat(web): login page and API authentication

### DIFF
--- a/web/src/App.css
+++ b/web/src/App.css
@@ -1551,6 +1551,111 @@ a {
   }
 }
 
+/* ── Login Page ── */
+
+.login-page {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  padding: 24px;
+  background:
+    radial-gradient(circle at top left, rgba(59, 130, 246, 0.14), transparent 24%),
+    radial-gradient(circle at bottom right, rgba(34, 197, 94, 0.1), transparent 20%),
+    var(--bg);
+}
+
+.login-card {
+  width: 100%;
+  max-width: 380px;
+  padding: 40px 32px;
+  border-radius: 24px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  backdrop-filter: blur(14px);
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.2);
+  text-align: center;
+}
+
+.login-header {
+  margin-bottom: 28px;
+}
+
+.login-header .brand-mark {
+  margin: 0 auto 16px;
+}
+
+.login-header h1 {
+  font-size: 1.3rem;
+  margin-bottom: 6px;
+}
+
+.login-header p {
+  color: var(--text-muted);
+  font-size: 0.85rem;
+}
+
+.login-form {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.login-input {
+  width: 100%;
+  padding: 12px 14px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  color: var(--text);
+  font-size: 0.92rem;
+}
+
+.login-input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.12);
+}
+
+.login-error {
+  color: var(--danger);
+  font-size: 0.82rem;
+}
+
+.login-btn {
+  padding: 12px;
+  background: var(--accent);
+  color: white;
+  border-radius: var(--radius);
+  font-weight: 500;
+  font-size: 0.95rem;
+  margin-top: 4px;
+}
+
+.login-btn:hover:not(:disabled) {
+  background: var(--accent-hover);
+}
+
+.login-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.btn-logout {
+  padding: 8px 14px;
+  border-radius: 999px;
+  background: transparent;
+  color: var(--text-muted);
+  border: 1px solid var(--border);
+  font-size: 0.82rem;
+}
+
+.btn-logout:hover {
+  background: var(--danger);
+  color: white;
+  border-color: var(--danger);
+}
+
 /* ── Toast ── */
 
 .toast-container {

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from 'react'
 import { NavLink, Navigate, Outlet, Route, Routes } from 'react-router-dom'
-import { healthCheck } from './api'
+import { healthCheck, hasAuth, clearAuth } from './api'
 import { ToastContainer } from './components/Toast'
+import { LoginPage } from './pages/LoginPage'
 import { NewTaskPage } from './pages/NewTaskPage'
 import { SessionsPage } from './pages/SessionsPage'
 import { SkillsPage } from './pages/SkillsPage'
@@ -59,6 +60,11 @@ function AppLayout({
           <button className="theme-toggle" onClick={onToggleTheme} type="button">
             {theme === 'dark' ? 'Light Mode' : 'Dark Mode'}
           </button>
+          {hasAuth() && (
+            <button className="btn-logout" onClick={() => { clearAuth(); window.location.reload() }} type="button">
+              退出
+            </button>
+          )}
         </div>
       </header>
 
@@ -72,7 +78,7 @@ function AppLayout({
 
 function App() {
   const [theme, setTheme] = useState<Theme>(getInitialTheme)
-  const [healthy, setHealthy] = useState(false)
+  const [status, setStatus] = useState<'loading' | 'needsAuth' | 'ready'>('loading')
 
   useEffect(() => {
     document.documentElement.dataset.theme = theme
@@ -81,27 +87,32 @@ function App() {
 
   useEffect(() => {
     healthCheck()
-      .then(() => setHealthy(true))
-      .catch(() => setHealthy(false))
+      .then(() => setStatus('ready'))
+      .catch((err) => {
+        if (err instanceof Error && err.message.includes('401')) {
+          setStatus('needsAuth')
+        } else if (hasAuth()) {
+          // Has stored auth but server might not require it
+          setStatus('ready')
+        } else {
+          setStatus('needsAuth')
+        }
+      })
   }, [])
 
-  if (!healthy) {
+  if (status === 'loading') {
     return (
       <div className="app-loading">
         <div className="loading-card">
           <div className="spinner" />
-          <p>正在连接后端服务 (localhost:4096)...</p>
-          <button
-            onClick={() => {
-              healthCheck().then(() => setHealthy(true)).catch(() => {})
-            }}
-            type="button"
-          >
-            重试
-          </button>
+          <p>正在连接后端服务...</p>
         </div>
       </div>
     )
+  }
+
+  if (status === 'needsAuth') {
+    return <LoginPage onLogin={() => setStatus('ready')} />
   }
 
   return (

--- a/web/src/api.ts
+++ b/web/src/api.ts
@@ -1,10 +1,37 @@
 export const API_BASE_URL = '/api'
 
+let authToken: string | null = localStorage.getItem('opencode-auth-token')
+
+export function setAuth(username: string, password: string) {
+  authToken = btoa(`${username}:${password}`)
+  localStorage.setItem('opencode-auth-token', authToken)
+}
+
+export function clearAuth() {
+  authToken = null
+  localStorage.removeItem('opencode-auth-token')
+}
+
+export function hasAuth() {
+  return authToken !== null
+}
+
+function authHeaders(): Record<string, string> {
+  const headers: Record<string, string> = { 'Content-Type': 'application/json' }
+  if (authToken) headers['Authorization'] = `Basic ${authToken}`
+  return headers
+}
+
 async function request<T>(path: string, options?: RequestInit): Promise<T> {
   const res = await fetch(`${API_BASE_URL}${path}`, {
-    headers: { 'Content-Type': 'application/json' },
+    headers: authHeaders(),
     ...options,
   })
+  if (res.status === 401) {
+    clearAuth()
+    window.location.reload()
+    throw new Error('认证失败，请重新登录')
+  }
   if (!res.ok) {
     const text = await res.text()
     throw new Error(`API ${res.status}: ${text}`)
@@ -87,7 +114,7 @@ export async function sendMessage(
 ) {
   const res = await fetch(`${API_BASE_URL}/session/${sessionID}/message`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: authHeaders(),
     body: JSON.stringify({ parts }),
   })
   if (!res.ok) {
@@ -178,7 +205,7 @@ export async function sendMessageAsyncWithOptions(
 ) {
   const res = await fetch(`${API_BASE_URL}/session/${sessionID}/prompt_async`, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
+    headers: authHeaders(),
     body: JSON.stringify({ parts, ...options }),
   })
   if (!res.ok) {

--- a/web/src/pages/LoginPage.tsx
+++ b/web/src/pages/LoginPage.tsx
@@ -1,0 +1,60 @@
+import { useState } from 'react'
+import { setAuth, healthCheck } from '../api'
+
+interface Props {
+  onLogin: () => void
+}
+
+export function LoginPage({ onLogin }: Props) {
+  const [username, setUsername] = useState('opencode')
+  const [password, setPassword] = useState('')
+  const [error, setError] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setLoading(true)
+    setError('')
+    setAuth(username, password)
+    try {
+      await healthCheck()
+      onLogin()
+    } catch {
+      setError('认证失败，请检查用户名和密码')
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="login-page">
+      <div className="login-card">
+        <div className="login-header">
+          <span className="brand-mark">OC</span>
+          <h1>OpenCode Agent</h1>
+          <p>请输入凭证登录</p>
+        </div>
+        <form onSubmit={handleSubmit} className="login-form">
+          <input
+            type="text"
+            value={username}
+            onChange={(e) => setUsername(e.target.value)}
+            placeholder="用户名"
+            className="login-input"
+            autoFocus
+          />
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="密码"
+            className="login-input"
+          />
+          {error && <p className="login-error">{error}</p>}
+          <button type="submit" className="login-btn" disabled={loading || !password}>
+            {loading ? '登录中...' : '登录'}
+          </button>
+        </form>
+      </div>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- 新增 LoginPage，支持 Basic Auth 登录
- API 层自动携带 Authorization header，401 时清除凭证并跳转登录
- Topbar 添加退出按钮
- 无密码配置时自动跳过登录

Closes #13

## Changes
- `web/src/pages/LoginPage.tsx`: 登录页面
- `web/src/api.ts`: auth token 管理 + 请求头注入
- `web/src/App.tsx`: 启动时检测认证状态
- `web/src/App.css`: 登录页和退出按钮样式

## Test Plan
- [x] `npx tsc --noEmit` 通过
- [x] `npm run build` 通过
- [ ] 设置 OPENCODE_SERVER_PASSWORD 后，访问需要登录
- [ ] 不设置密码时，自动跳过登录